### PR TITLE
Make blog LIVE with turbo

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,4 @@
 class Comment < ApplicationRecord
   belongs_to :post
+  broadcasts_to :post
 end

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -1,3 +1,5 @@
+/ Using dom_id(comment) to make the id is essential for a turbo stream to work.
+/ This approach should be your standard for all item partials from now on.
 div id="#{dom_id(comment)}"
   p= comment.content
   small= time_tag comment.created_at, "data-local": "time-ago"

--- a/app/views/posts/_comments.html.slim
+++ b/app/views/posts/_comments.html.slim
@@ -1,4 +1,6 @@
 h2 Comments
 
-.comments= render post.comments
+/ This section must use an ID 'comments' for the turbo stream to work
+#comments= render post.comments
+
 = render "comments/new", post: post

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -1,3 +1,4 @@
+= turbo_stream_from @post
 p#notice = notice
 
 = render @post


### PR DESCRIPTION
- comments broadcast to their post
- commented the use of ids in the views which are essential to make this
  work
- irb needs to be reloaded (perhaps restarted) for a new turbo stream to
  work
- there needs to be a new standard for item partials so that they can
  easily become part of a stream. All item partials should follow the
  convention of using dom_id to create their id.